### PR TITLE
deploy コマンドをステージング、本番用に分割

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
   "scripts": {
     "login": "wrangler login",
     "start": "wrangler dev --env staging",
-    "deploy": "wrangler publish",
+    "deploy:production": "wrangler publish",
+    "deploy:staging": "wrangler publish --env staging",
     "lint:prettier": "prettier --check .",
     "fix:prettier": "npm run lint:prettier -- --write",
     "lint:eslint": "eslint .",


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-bff/issues/4

# 関連 URL

なし

# Done の定義

- npm scriptsのデプロイコマンドがステージング、本番用でそれぞれ定義されている事

# スクリーンショット

なし

# 変更点概要

自動デプロイを設定する為にステージング、本番用のデプロイコマンドをそれぞれ別で定義するように変更。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし