### PR TITLE
例外発生時のエラーレスポンスの設定を追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "lgtm-cat-bff",
       "version": "0.0.0",
       "dependencies": {
+        "@honojs/sentry": "^0.0.5",
         "hono": "^2.6.2",
         "zod": "^3.20.2"
       },
@@ -726,6 +727,17 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@honojs/sentry": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@honojs/sentry/-/sentry-0.0.5.tgz",
+      "integrity": "sha512-U28ADTMvDNfeuVghGz2gwae52DFhMuhzZ/E227I2IrT6TXrroUMRfCGYgKrn1oHts7qSmemubHuULkv2EqC54g==",
+      "dependencies": {
+        "toucan-js": "^2.6.1"
+      },
+      "peerDependencies": {
+        "hono": "^2.6.1"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -1527,6 +1539,87 @@
       "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-1.0.3.tgz",
       "integrity": "sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q==",
       "dev": true
+    },
+    "node_modules/@sentry/core": {
+      "version": "6.19.6",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.19.6.tgz",
+      "integrity": "sha512-biEotGRr44/vBCOegkTfC9rwqaqRKIpFljKGyYU6/NtzMRooktqOhjmjmItNCMRknArdeaQwA8lk2jcZDXX3Og==",
+      "dependencies": {
+        "@sentry/hub": "6.19.6",
+        "@sentry/minimal": "6.19.6",
+        "@sentry/types": "6.19.6",
+        "@sentry/utils": "6.19.6",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@sentry/core/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@sentry/hub": {
+      "version": "6.19.6",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.19.6.tgz",
+      "integrity": "sha512-PuEOBZxvx3bjxcXmWWZfWXG+orojQiWzv9LQXjIgroVMKM/GG4QtZbnWl1hOckUj7WtKNl4hEGO2g/6PyCV/vA==",
+      "dependencies": {
+        "@sentry/types": "6.19.6",
+        "@sentry/utils": "6.19.6",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@sentry/hub/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@sentry/minimal": {
+      "version": "6.19.6",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.19.6.tgz",
+      "integrity": "sha512-T1NKcv+HTlmd8EbzUgnGPl4ySQGHWMCyZ8a8kXVMZOPDzphN3fVIzkYzWmSftCWp0rpabXPt9aRF2mfBKU+mAQ==",
+      "dependencies": {
+        "@sentry/hub": "6.19.6",
+        "@sentry/types": "6.19.6",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@sentry/minimal/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@sentry/types": {
+      "version": "6.19.6",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.19.6.tgz",
+      "integrity": "sha512-QH34LMJidEUPZK78l+Frt3AaVFJhEmIi05Zf8WHd9/iTt+OqvCHBgq49DDr1FWFqyYWm/QgW/3bIoikFpfsXyQ==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@sentry/utils": {
+      "version": "6.19.6",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.19.6.tgz",
+      "integrity": "sha512-fAMWcsguL0632eWrROp/vhPgI7sBj/JROWVPzpabwVkm9z3m1rQm6iLFn4qfkZL8Ozy6NVZPXOQ7EXmeU24byg==",
+      "dependencies": {
+        "@sentry/types": "6.19.6",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@sentry/utils/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.24.51",
@@ -2973,6 +3066,14 @@
       "dev": true,
       "dependencies": {
         "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/error-stack-parser": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.1.4.tgz",
+      "integrity": "sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==",
+      "dependencies": {
+        "stackframe": "^1.3.4"
       }
     },
     "node_modules/es-abstract": {
@@ -7774,6 +7875,14 @@
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true
     },
+    "node_modules/stack-generator": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.10.tgz",
+      "integrity": "sha512-mwnua/hkqM6pF4k8SnmZ2zfETsRUpWXREfA/goT8SLCV4iOFa4bzOX2nDipWAZFPTjLvQB82f5yaodMVhK0yJQ==",
+      "dependencies": {
+        "stackframe": "^1.3.4"
+      }
+    },
     "node_modules/stack-trace": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
@@ -7802,6 +7911,38 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/stackframe": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
+      "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw=="
+    },
+    "node_modules/stacktrace-gps": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/stacktrace-gps/-/stacktrace-gps-3.1.2.tgz",
+      "integrity": "sha512-GcUgbO4Jsqqg6RxfyTHFiPxdPqF+3LFmQhm7MgCuYQOYuWyqxo5pwRPz5d/u6/WYJdEnWfK4r+jGbyD8TSggXQ==",
+      "dependencies": {
+        "source-map": "0.5.6",
+        "stackframe": "^1.3.4"
+      }
+    },
+    "node_modules/stacktrace-gps/node_modules/source-map": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+      "integrity": "sha512-MjZkVp0NHr5+TPihLcadqnlVoGIoWo4IBHptutGh9wI3ttUYvCG26HkSuDi+K6lsZ25syXJXcctwgyVCt//xqA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stacktrace-js": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/stacktrace-js/-/stacktrace-js-2.0.2.tgz",
+      "integrity": "sha512-Je5vBeY4S1r/RnLydLl0TBTi3F2qdfWmYsGvtfZgEI+SCprPppaIhQf5nGcal4gI4cGpCV/duLcAzT1np6sQqg==",
+      "dependencies": {
+        "error-stack-parser": "^2.0.6",
+        "stack-generator": "^2.0.5",
+        "stacktrace-gps": "^3.0.4"
       }
     },
     "node_modules/streamsearch": {
@@ -8041,6 +8182,33 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/toucan-js": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/toucan-js/-/toucan-js-2.7.0.tgz",
+      "integrity": "sha512-vbvRbFfMLN2Jf9lOkwL1KwIwuCcS/ko0MVACZTYTnbdVlVjsIviwCU0inH0CRcMXCvFAS+uL8z/gSV3y7FpZUQ==",
+      "dependencies": {
+        "@sentry/core": "6.19.6",
+        "@sentry/hub": "6.19.6",
+        "@sentry/types": "6.19.6",
+        "@sentry/utils": "6.19.6",
+        "@types/cookie": "0.5.0",
+        "cookie": "0.5.0",
+        "stacktrace-js": "2.0.2"
+      }
+    },
+    "node_modules/toucan-js/node_modules/@types/cookie": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.5.0.tgz",
+      "integrity": "sha512-CJWHVHHupxBYfIlMM+qzXx4dRKIV1VzOm0cP3Wpqten8MDx1tK+y92YDXUshN1ONAfwodvKxDNkw35/pNs+izg=="
+    },
+    "node_modules/toucan-js/node_modules/cookie": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/tough-cookie": {
@@ -9306,6 +9474,14 @@
         "strip-json-comments": "^3.1.1"
       }
     },
+    "@honojs/sentry": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@honojs/sentry/-/sentry-0.0.5.tgz",
+      "integrity": "sha512-U28ADTMvDNfeuVghGz2gwae52DFhMuhzZ/E227I2IrT6TXrroUMRfCGYgKrn1oHts7qSmemubHuULkv2EqC54g==",
+      "requires": {
+        "toucan-js": "^2.6.1"
+      }
+    },
     "@humanwhocodes/config-array": {
       "version": "0.11.8",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.8.tgz",
@@ -9934,6 +10110,80 @@
       "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-1.0.3.tgz",
       "integrity": "sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q==",
       "dev": true
+    },
+    "@sentry/core": {
+      "version": "6.19.6",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.19.6.tgz",
+      "integrity": "sha512-biEotGRr44/vBCOegkTfC9rwqaqRKIpFljKGyYU6/NtzMRooktqOhjmjmItNCMRknArdeaQwA8lk2jcZDXX3Og==",
+      "requires": {
+        "@sentry/hub": "6.19.6",
+        "@sentry/minimal": "6.19.6",
+        "@sentry/types": "6.19.6",
+        "@sentry/utils": "6.19.6",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@sentry/hub": {
+      "version": "6.19.6",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.19.6.tgz",
+      "integrity": "sha512-PuEOBZxvx3bjxcXmWWZfWXG+orojQiWzv9LQXjIgroVMKM/GG4QtZbnWl1hOckUj7WtKNl4hEGO2g/6PyCV/vA==",
+      "requires": {
+        "@sentry/types": "6.19.6",
+        "@sentry/utils": "6.19.6",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@sentry/minimal": {
+      "version": "6.19.6",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.19.6.tgz",
+      "integrity": "sha512-T1NKcv+HTlmd8EbzUgnGPl4ySQGHWMCyZ8a8kXVMZOPDzphN3fVIzkYzWmSftCWp0rpabXPt9aRF2mfBKU+mAQ==",
+      "requires": {
+        "@sentry/hub": "6.19.6",
+        "@sentry/types": "6.19.6",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@sentry/types": {
+      "version": "6.19.6",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.19.6.tgz",
+      "integrity": "sha512-QH34LMJidEUPZK78l+Frt3AaVFJhEmIi05Zf8WHd9/iTt+OqvCHBgq49DDr1FWFqyYWm/QgW/3bIoikFpfsXyQ=="
+    },
+    "@sentry/utils": {
+      "version": "6.19.6",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.19.6.tgz",
+      "integrity": "sha512-fAMWcsguL0632eWrROp/vhPgI7sBj/JROWVPzpabwVkm9z3m1rQm6iLFn4qfkZL8Ozy6NVZPXOQ7EXmeU24byg==",
+      "requires": {
+        "@sentry/types": "6.19.6",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
     },
     "@sinclair/typebox": {
       "version": "0.24.51",
@@ -11011,6 +11261,14 @@
       "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
+      }
+    },
+    "error-stack-parser": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.1.4.tgz",
+      "integrity": "sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==",
+      "requires": {
+        "stackframe": "^1.3.4"
       }
     },
     "es-abstract": {
@@ -14427,6 +14685,14 @@
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true
     },
+    "stack-generator": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.10.tgz",
+      "integrity": "sha512-mwnua/hkqM6pF4k8SnmZ2zfETsRUpWXREfA/goT8SLCV4iOFa4bzOX2nDipWAZFPTjLvQB82f5yaodMVhK0yJQ==",
+      "requires": {
+        "stackframe": "^1.3.4"
+      }
+    },
     "stack-trace": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
@@ -14448,6 +14714,37 @@
           "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
           "dev": true
         }
+      }
+    },
+    "stackframe": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
+      "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw=="
+    },
+    "stacktrace-gps": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/stacktrace-gps/-/stacktrace-gps-3.1.2.tgz",
+      "integrity": "sha512-GcUgbO4Jsqqg6RxfyTHFiPxdPqF+3LFmQhm7MgCuYQOYuWyqxo5pwRPz5d/u6/WYJdEnWfK4r+jGbyD8TSggXQ==",
+      "requires": {
+        "source-map": "0.5.6",
+        "stackframe": "^1.3.4"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha512-MjZkVp0NHr5+TPihLcadqnlVoGIoWo4IBHptutGh9wI3ttUYvCG26HkSuDi+K6lsZ25syXJXcctwgyVCt//xqA=="
+        }
+      }
+    },
+    "stacktrace-js": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/stacktrace-js/-/stacktrace-js-2.0.2.tgz",
+      "integrity": "sha512-Je5vBeY4S1r/RnLydLl0TBTi3F2qdfWmYsGvtfZgEI+SCprPppaIhQf5nGcal4gI4cGpCV/duLcAzT1np6sQqg==",
+      "requires": {
+        "error-stack-parser": "^2.0.6",
+        "stack-generator": "^2.0.5",
+        "stacktrace-gps": "^3.0.4"
       }
     },
     "streamsearch": {
@@ -14627,6 +14924,32 @@
       "dev": true,
       "requires": {
         "is-number": "^7.0.0"
+      }
+    },
+    "toucan-js": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/toucan-js/-/toucan-js-2.7.0.tgz",
+      "integrity": "sha512-vbvRbFfMLN2Jf9lOkwL1KwIwuCcS/ko0MVACZTYTnbdVlVjsIviwCU0inH0CRcMXCvFAS+uL8z/gSV3y7FpZUQ==",
+      "requires": {
+        "@sentry/core": "6.19.6",
+        "@sentry/hub": "6.19.6",
+        "@sentry/types": "6.19.6",
+        "@sentry/utils": "6.19.6",
+        "@types/cookie": "0.5.0",
+        "cookie": "0.5.0",
+        "stacktrace-js": "2.0.2"
+      },
+      "dependencies": {
+        "@types/cookie": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.5.0.tgz",
+          "integrity": "sha512-CJWHVHHupxBYfIlMM+qzXx4dRKIV1VzOm0cP3Wpqten8MDx1tK+y92YDXUshN1ONAfwodvKxDNkw35/pNs+izg=="
+        },
+        "cookie": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+          "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw=="
+        }
       }
     },
     "tough-cookie": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "test": "jest --verbose"
   },
   "dependencies": {
+    "@honojs/sentry": "^0.0.5",
     "hono": "^2.6.2",
     "zod": "^3.20.2"
   }

--- a/src/bindings.d.ts
+++ b/src/bindings.d.ts
@@ -6,4 +6,5 @@ export type Bindings = {
   IMAGE_RECOGNITION_API_URL: `https://${string}`;
   LGTMEOW_API_URL: `https://${string}`;
   COGNITO_TOKEN: KVNamespace;
+  SENTRY_DSN: `https://${string}@${string}.ingest.sentry.io/${string}`;
 };

--- a/src/handlers/handleNotFound.ts
+++ b/src/handlers/handleNotFound.ts
@@ -1,0 +1,17 @@
+import { httpStatusCode } from '../httpStatusCode';
+import { createErrorResponse } from './handlerResponse';
+
+type Dto = {
+  url: string;
+};
+
+export const handleNotFound = (dto: Dto): Response => {
+  const problemDetails = {
+    title: 'not found',
+    type: 'ResourceNotFound',
+    detail: `${dto.url} is not found.`,
+    status: httpStatusCode.notFound,
+  } as const;
+
+  return createErrorResponse(problemDetails, httpStatusCode.notFound);
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,19 @@
+import { getSentry, sentry } from '@honojs/sentry';
 import { Hono } from 'hono';
 import { cors } from 'hono/cors';
-import { Bindings } from './bindings';
+import type { Bindings } from './bindings';
 import { handleFetchLgtmImagesInRandom } from './handlers/handleFetchLgtmImagesInRandom';
 import { handleNotFound } from './handlers/handleNotFound';
+import type { ProblemDetails } from './handlers/handlerResponse';
+import { httpStatusCode } from './httpStatusCode';
 
 const app = new Hono<{ Bindings: Bindings }>();
 
-app.get('/', (c) => c.text('Hello! Hono!'));
+app.use('*', async (c, next) => {
+  const handler = sentry({ dsn: c.env.SENTRY_DSN });
+
+  await handler(c, next);
+});
 
 app.use('*', async (c, next) => {
   const handler =
@@ -27,6 +34,21 @@ app.get('/lgtm-images', async (c) => {
       cacheClient: c.env.COGNITO_TOKEN,
     },
   });
+});
+
+app.onError((error, c) => {
+  const problemDetails: ProblemDetails = {
+    title: error.name,
+    type: 'InternalServerError',
+    status: httpStatusCode.internalServerError,
+  } as const;
+
+  const sentryHandler = getSentry(c);
+  sentryHandler.setTag('requestIds', error.message);
+  sentryHandler.setTag('environment', c.env.APP_ENV);
+  sentryHandler.captureException(error);
+
+  return c.json(problemDetails, httpStatusCode.internalServerError);
 });
 
 app.all('*', (c) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono';
 import { cors } from 'hono/cors';
 import { Bindings } from './bindings';
 import { handleFetchLgtmImagesInRandom } from './handlers/handleFetchLgtmImagesInRandom';
+import { handleNotFound } from './handlers/handleNotFound';
 
 const app = new Hono<{ Bindings: Bindings }>();
 
@@ -26,6 +27,10 @@ app.get('/lgtm-images', async (c) => {
       cacheClient: c.env.COGNITO_TOKEN,
     },
   });
+});
+
+app.all('*', (c) => {
+  return handleNotFound({ url: c.req.url });
 });
 
 export default app;


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-bff/issues/10

# 関連 URL

- なし

# Done の定義

- https://github.com/nekochans/lgtm-cat-bff/issues/10 のDoneの定義を満たしている事

# スクリーンショット

![Sentry](https://user-images.githubusercontent.com/11032365/209687329-91a1e243-cd21-489b-a197-dae7f1e46275.png)

# 変更点概要

例外発生時と404の際に専用のJSONレスポンスを返すように変更。

エラー時のFormatは [RFC7807](https://www.eisbahn.jp/yoichiro/2017/01/rfc_7807.html) を参考に設定した。

## 404時のレスポンス

```
{
  "title": "not found",
  "type": "ResourceNotFound",
  "detail": "https://xxxxxxx/ is not found.",
  "status": 404
}
```

## 例外発生時（500）のレスポンス、titleの部分は動的に変更される

```
{
  "title": "Error",
  "type": "InternalServerError",
  "status": 500
}
```

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし