### PR TITLE
POST /cat-images/validation-results へ通信を行うエンドポイントを実装

### DIFF
--- a/src/api/__tests__/isAcceptableCatImage.spec.ts
+++ b/src/api/__tests__/isAcceptableCatImage.spec.ts
@@ -1,0 +1,55 @@
+/**
+ * @jest-environment jsdom
+ */
+import 'whatwg-fetch';
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+import { mockIsAcceptableCatImageTrue } from '../../mocks/api/mockIsAcceptableCatImageTrue';
+import { isSuccessResult } from '../../result';
+import { isAcceptableCatImage } from '../isAcceptableCatImage';
+
+const apiUrl = 'https://api.example.com';
+
+const mockHandlers = [
+  rest.post(
+    `${apiUrl}/cat-images/validation-results`,
+    mockIsAcceptableCatImageTrue
+  ),
+];
+
+const mockServer = setupServer(...mockHandlers);
+
+// eslint-disable-next-line max-lines-per-function
+describe('isAcceptableCatImage TestCases', () => {
+  beforeAll(() => {
+    mockServer.listen();
+  });
+
+  afterEach(() => {
+    mockServer.resetHandlers();
+  });
+
+  afterAll(() => {
+    mockServer.close();
+  });
+
+  // eslint-disable-next-line max-lines-per-function
+  it('should return isAcceptableCatImage as true', async () => {
+    const expected = {
+      isAcceptableCatImageResponse: {
+        isAcceptableCatImage: true,
+      },
+      xRequestId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+      xLambdaRequestId: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+    };
+
+    const result = await isAcceptableCatImage({
+      apiBaseUrl: apiUrl,
+      accessToken: '',
+      jsonRequestBody: JSON.stringify({ image: '', imageExtension: '.jpeg' }),
+    });
+
+    expect(isSuccessResult(result)).toBeTruthy();
+    expect(result.value).toStrictEqual(expected);
+  });
+});

--- a/src/api/__tests__/isAcceptableCatImage.spec.ts
+++ b/src/api/__tests__/isAcceptableCatImage.spec.ts
@@ -4,8 +4,16 @@
 import 'whatwg-fetch';
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
+import { mockInternalServerError } from '../../mocks/api/error/mockInternalServerError';
+import { mockIsAcceptableCatImageNotAllowedImageExtension } from '../../mocks/api/mockIsAcceptableCatImageNotAllowedImageExtension';
+import { mockIsAcceptableCatImageNotCatImage } from '../../mocks/api/mockIsAcceptableCatImageNotCatImage';
+import { mockIsAcceptableCatImageNotModerationImage } from '../../mocks/api/mockIsAcceptableCatImageNotModerationImage';
+import { mockIsAcceptableCatImagePersonFaceInTheImage } from '../../mocks/api/mockIsAcceptableCatImagePersonFaceInTheImage';
 import { mockIsAcceptableCatImageTrue } from '../../mocks/api/mockIsAcceptableCatImageTrue';
+import { mockIsAcceptableCatImageUnexpectedError } from '../../mocks/api/mockIsAcceptableCatImageUnexpectedError';
+import { mockIsAcceptableCatImageUnexpectedResponseBody } from '../../mocks/api/mockIsAcceptableCatImageUnexpectedResponseBody';
 import { isSuccessResult } from '../../result';
+import { IsAcceptableCatImageError } from '../errors/IsAcceptableCatImageError';
 import { isAcceptableCatImage } from '../isAcceptableCatImage';
 
 const apiUrl = 'https://api.example.com';
@@ -51,5 +59,185 @@ describe('isAcceptableCatImage TestCases', () => {
 
     expect(isSuccessResult(result)).toBeTruthy();
     expect(result.value).toStrictEqual(expected);
+  });
+
+  it('should return isAcceptableCatImage as false because not allowed image extension', async () => {
+    mockServer.use(
+      rest.post(
+        `${apiUrl}/cat-images/validation-results`,
+        mockIsAcceptableCatImageNotAllowedImageExtension
+      )
+    );
+
+    const expected = {
+      isAcceptableCatImageResponse: {
+        isAcceptableCatImage: false,
+        notAcceptableReason: 'not an allowed image extension',
+      },
+      xRequestId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+      xLambdaRequestId: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+    };
+
+    const result = await isAcceptableCatImage({
+      apiBaseUrl: apiUrl,
+      accessToken: '',
+      jsonRequestBody: JSON.stringify({ image: '', imageExtension: '.webp' }),
+    });
+
+    expect(isSuccessResult(result)).toBeTruthy();
+    expect(result.value).toStrictEqual(expected);
+  });
+
+  it('should return isAcceptableCatImage as false because not moderation image', async () => {
+    mockServer.use(
+      rest.post(
+        `${apiUrl}/cat-images/validation-results`,
+        mockIsAcceptableCatImageNotModerationImage
+      )
+    );
+
+    const expected = {
+      isAcceptableCatImageResponse: {
+        isAcceptableCatImage: false,
+        notAcceptableReason: 'not moderation image',
+      },
+      xRequestId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+      xLambdaRequestId: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+    };
+
+    const result = await isAcceptableCatImage({
+      apiBaseUrl: apiUrl,
+      accessToken: '',
+      jsonRequestBody: JSON.stringify({ image: '', imageExtension: '.png' }),
+    });
+
+    expect(isSuccessResult(result)).toBeTruthy();
+    expect(result.value).toStrictEqual(expected);
+  });
+
+  it('should return isAcceptableCatImage as false because person face in the image', async () => {
+    mockServer.use(
+      rest.post(
+        `${apiUrl}/cat-images/validation-results`,
+        mockIsAcceptableCatImagePersonFaceInTheImage
+      )
+    );
+
+    const expected = {
+      isAcceptableCatImageResponse: {
+        isAcceptableCatImage: false,
+        notAcceptableReason: 'person face in the image',
+      },
+      xRequestId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+      xLambdaRequestId: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+    };
+
+    const result = await isAcceptableCatImage({
+      apiBaseUrl: apiUrl,
+      accessToken: '',
+      jsonRequestBody: JSON.stringify({ image: '', imageExtension: '.png' }),
+    });
+
+    expect(isSuccessResult(result)).toBeTruthy();
+    expect(result.value).toStrictEqual(expected);
+  });
+
+  it('should return isAcceptableCatImage as false because not cat image', async () => {
+    mockServer.use(
+      rest.post(
+        `${apiUrl}/cat-images/validation-results`,
+        mockIsAcceptableCatImageNotCatImage
+      )
+    );
+
+    const expected = {
+      isAcceptableCatImageResponse: {
+        isAcceptableCatImage: false,
+        notAcceptableReason: 'not cat image',
+      },
+      xRequestId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+      xLambdaRequestId: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+    };
+
+    const result = await isAcceptableCatImage({
+      apiBaseUrl: apiUrl,
+      accessToken: '',
+      jsonRequestBody: JSON.stringify({ image: '', imageExtension: '.png' }),
+    });
+
+    expect(isSuccessResult(result)).toBeTruthy();
+    expect(result.value).toStrictEqual(expected);
+  });
+
+  it('should return isAcceptableCatImage as false because unexpected error', async () => {
+    mockServer.use(
+      rest.post(
+        `${apiUrl}/cat-images/validation-results`,
+        mockIsAcceptableCatImageUnexpectedError
+      )
+    );
+
+    const expected = {
+      isAcceptableCatImageResponse: {
+        isAcceptableCatImage: false,
+        notAcceptableReason: 'an error has occurred',
+      },
+      xRequestId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+      xLambdaRequestId: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+    };
+
+    const result = await isAcceptableCatImage({
+      apiBaseUrl: apiUrl,
+      accessToken: '',
+      jsonRequestBody: JSON.stringify({ image: '', imageExtension: '.png' }),
+    });
+
+    expect(isSuccessResult(result)).toBeTruthy();
+    expect(result.value).toStrictEqual(expected);
+  });
+
+  it('should return a ValidationErrorResponse because the API returns an unexpected response body', async () => {
+    mockServer.use(
+      rest.post(
+        `${apiUrl}/cat-images/validation-results`,
+        mockIsAcceptableCatImageUnexpectedResponseBody
+      )
+    );
+
+    const expected = {
+      invalidParams: [{ name: 'isAcceptableCatImage', reason: 'Required' }],
+      xRequestId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+      xLambdaRequestId: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+    };
+
+    const result = await isAcceptableCatImage({
+      apiBaseUrl: apiUrl,
+      accessToken: '',
+      jsonRequestBody: JSON.stringify({ image: '', imageExtension: '.png' }),
+    });
+
+    expect(isSuccessResult(result)).toBeFalsy();
+    expect(result.value).toStrictEqual(expected);
+  });
+
+  it('should Throw IsAcceptableCatImageError because the API returns an unexpected error', async () => {
+    mockServer.use(
+      rest.post(
+        `${apiUrl}/cat-images/validation-results`,
+        mockInternalServerError
+      )
+    );
+
+    await expect(
+      isAcceptableCatImage({
+        apiBaseUrl: apiUrl,
+        accessToken: '',
+        jsonRequestBody: JSON.stringify({ image: '', imageExtension: '.png' }),
+      })
+    ).rejects.toStrictEqual(
+      new IsAcceptableCatImageError(
+        'X-Request-Id=aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa:X-Lambda-Request-Id:bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'
+      )
+    );
   });
 });

--- a/src/handlers/handleCatImageValidation.ts
+++ b/src/handlers/handleCatImageValidation.ts
@@ -1,0 +1,115 @@
+import { z } from 'zod';
+import type { CacheClient } from '../api/cacheClient';
+import { isAcceptableCatImage } from '../api/isAcceptableCatImage';
+import { issueAccessToken } from '../api/issueAccessToken';
+import { isValidationErrorResponse } from '../api/validationErrorResponse';
+import { httpStatusCode } from '../httpStatusCode';
+import type { AcceptedTypesImageExtension } from '../lgtmImage';
+import { acceptedTypesImageExtensions } from '../lgtmImage';
+import { isFailureResult } from '../result';
+import { validation, ValidationResult } from '../validator';
+import {
+  createErrorResponse,
+  createSuccessResponse,
+  createValidationErrorResponse,
+  ResponseHeader,
+} from './handlerResponse';
+
+type Dto = {
+  env: {
+    cognitoTokenEndpoint: string;
+    cognitoClientId: string;
+    cognitoClientSecret: string;
+    apiBaseUrl: string;
+    cacheClient: CacheClient;
+  };
+  requestBody: {
+    image: string;
+    imageExtension: AcceptedTypesImageExtension;
+  };
+};
+
+export const validateHandleCatImageValidationRequestBody = (
+  value: unknown
+): ValidationResult => {
+  const schema = z.object({
+    image: z.string().min(1),
+    imageExtension: z.enum(acceptedTypesImageExtensions),
+  });
+
+  return validation(schema, value);
+};
+
+export const handleCatImageValidation = async (dto: Dto): Promise<Response> => {
+  const issueTokenRequest = {
+    endpoint: dto.env.cognitoTokenEndpoint,
+    cognitoClientId: dto.env.cognitoClientId,
+    cognitoClientSecret: dto.env.cognitoClientSecret,
+    cacheClient: dto.env.cacheClient,
+  };
+
+  const issueAccessTokenResult = await issueAccessToken(issueTokenRequest);
+  if (isFailureResult(issueAccessTokenResult)) {
+    const problemDetails = {
+      title: 'failed to issue access token',
+      type: 'InternalServerError',
+      status: httpStatusCode.internalServerError,
+    } as const;
+
+    return createErrorResponse(
+      problemDetails,
+      httpStatusCode.internalServerError
+    );
+  }
+
+  const jsonRequestBody = JSON.stringify(dto.requestBody);
+
+  const isAcceptableCatImageDto = {
+    apiBaseUrl: dto.env.apiBaseUrl,
+    accessToken: issueAccessTokenResult.value.jwtAccessToken,
+    jsonRequestBody,
+  };
+
+  const isAcceptableCatImageResult = await isAcceptableCatImage(
+    isAcceptableCatImageDto
+  );
+
+  const headers: ResponseHeader = {
+    'Content-Type': 'application/json',
+  };
+
+  if (isAcceptableCatImageResult.value.xRequestId != null) {
+    headers['X-Request-Id'] = isAcceptableCatImageResult.value.xRequestId;
+  }
+
+  if (isAcceptableCatImageResult.value.xLambdaRequestId != null) {
+    headers['X-Lambda-Request-Id'] =
+      isAcceptableCatImageResult.value.xLambdaRequestId;
+  }
+
+  if (isFailureResult(isAcceptableCatImageResult)) {
+    if (isValidationErrorResponse(isAcceptableCatImageResult.value)) {
+      return createValidationErrorResponse(
+        isAcceptableCatImageResult.value.invalidParams,
+        headers
+      );
+    }
+
+    const problemDetails = {
+      title: 'failed to is acceptable cat image',
+      type: 'InternalServerError',
+      status: httpStatusCode.internalServerError,
+    } as const;
+
+    return createErrorResponse(
+      problemDetails,
+      httpStatusCode.internalServerError,
+      headers
+    );
+  }
+
+  const responseBody =
+    isAcceptableCatImageResult.value.isAcceptableCatImageResponse;
+
+  return createSuccessResponse(responseBody, httpStatusCode.ok, headers);
+};

--- a/src/mocks/api/mockIsAcceptableCatImageNotAllowedImageExtension.ts
+++ b/src/mocks/api/mockIsAcceptableCatImageNotAllowedImageExtension.ts
@@ -1,0 +1,18 @@
+import { ResponseResolver, MockedRequest, restContext } from 'msw';
+
+import { httpStatusCode } from '../../httpStatusCode';
+
+export const mockIsAcceptableCatImageNotAllowedImageExtension: ResponseResolver<
+  MockedRequest,
+  typeof restContext
+> = (_req, res, ctx) =>
+  res(
+    ctx.status(httpStatusCode.ok),
+    ctx.set('Content-Type', 'application/json'),
+    ctx.set('X-request-Id', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'),
+    ctx.set('X-lambda-request-Id', 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'),
+    ctx.json({
+      isAcceptableCatImage: false,
+      notAcceptableReason: 'not an allowed image extension',
+    })
+  );

--- a/src/mocks/api/mockIsAcceptableCatImageNotCatImage.ts
+++ b/src/mocks/api/mockIsAcceptableCatImageNotCatImage.ts
@@ -1,0 +1,18 @@
+import { ResponseResolver, MockedRequest, restContext } from 'msw';
+
+import { httpStatusCode } from '../../httpStatusCode';
+
+export const mockIsAcceptableCatImageNotCatImage: ResponseResolver<
+  MockedRequest,
+  typeof restContext
+> = (_req, res, ctx) =>
+  res(
+    ctx.status(httpStatusCode.ok),
+    ctx.set('Content-Type', 'application/json'),
+    ctx.set('X-request-Id', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'),
+    ctx.set('X-lambda-request-Id', 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'),
+    ctx.json({
+      isAcceptableCatImage: false,
+      notAcceptableReason: 'not cat image',
+    })
+  );

--- a/src/mocks/api/mockIsAcceptableCatImageNotModerationImage.ts
+++ b/src/mocks/api/mockIsAcceptableCatImageNotModerationImage.ts
@@ -1,0 +1,18 @@
+import { ResponseResolver, MockedRequest, restContext } from 'msw';
+
+import { httpStatusCode } from '../../httpStatusCode';
+
+export const mockIsAcceptableCatImageNotModerationImage: ResponseResolver<
+  MockedRequest,
+  typeof restContext
+> = (_req, res, ctx) =>
+  res(
+    ctx.status(httpStatusCode.ok),
+    ctx.set('Content-Type', 'application/json'),
+    ctx.set('X-request-Id', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'),
+    ctx.set('X-lambda-request-Id', 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'),
+    ctx.json({
+      isAcceptableCatImage: false,
+      notAcceptableReason: 'not moderation image',
+    })
+  );

--- a/src/mocks/api/mockIsAcceptableCatImagePersonFaceInTheImage.ts
+++ b/src/mocks/api/mockIsAcceptableCatImagePersonFaceInTheImage.ts
@@ -1,0 +1,18 @@
+import { ResponseResolver, MockedRequest, restContext } from 'msw';
+
+import { httpStatusCode } from '../../httpStatusCode';
+
+export const mockIsAcceptableCatImagePersonFaceInTheImage: ResponseResolver<
+  MockedRequest,
+  typeof restContext
+> = (_req, res, ctx) =>
+  res(
+    ctx.status(httpStatusCode.ok),
+    ctx.set('Content-Type', 'application/json'),
+    ctx.set('X-request-Id', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'),
+    ctx.set('X-lambda-request-Id', 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'),
+    ctx.json({
+      isAcceptableCatImage: false,
+      notAcceptableReason: 'person face in the image',
+    })
+  );

--- a/src/mocks/api/mockIsAcceptableCatImageTrue.ts
+++ b/src/mocks/api/mockIsAcceptableCatImageTrue.ts
@@ -1,0 +1,17 @@
+import { ResponseResolver, MockedRequest, restContext } from 'msw';
+
+import { httpStatusCode } from '../../httpStatusCode';
+
+export const mockIsAcceptableCatImageTrue: ResponseResolver<
+  MockedRequest,
+  typeof restContext
+> = (_req, res, ctx) =>
+  res(
+    ctx.status(httpStatusCode.ok),
+    ctx.set('Content-Type', 'application/json'),
+    ctx.set('X-request-Id', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'),
+    ctx.set('X-lambda-request-Id', 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'),
+    ctx.json({
+      isAcceptableCatImage: true,
+    })
+  );

--- a/src/mocks/api/mockIsAcceptableCatImageUnexpectedError.ts
+++ b/src/mocks/api/mockIsAcceptableCatImageUnexpectedError.ts
@@ -1,0 +1,18 @@
+import { ResponseResolver, MockedRequest, restContext } from 'msw';
+
+import { httpStatusCode } from '../../httpStatusCode';
+
+export const mockIsAcceptableCatImageUnexpectedError: ResponseResolver<
+  MockedRequest,
+  typeof restContext
+> = (_req, res, ctx) =>
+  res(
+    ctx.status(httpStatusCode.ok),
+    ctx.set('Content-Type', 'application/json'),
+    ctx.set('X-request-Id', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'),
+    ctx.set('X-lambda-request-Id', 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'),
+    ctx.json({
+      isAcceptableCatImage: false,
+      notAcceptableReason: 'an error has occurred',
+    })
+  );

--- a/src/mocks/api/mockIsAcceptableCatImageUnexpectedResponseBody.tsx
+++ b/src/mocks/api/mockIsAcceptableCatImageUnexpectedResponseBody.tsx
@@ -1,0 +1,17 @@
+import { ResponseResolver, MockedRequest, restContext } from 'msw';
+
+import { httpStatusCode } from '../../httpStatusCode';
+
+export const mockIsAcceptableCatImageUnexpectedResponseBody: ResponseResolver<
+  MockedRequest,
+  typeof restContext
+> = (_req, res, ctx) =>
+  res(
+    ctx.status(httpStatusCode.ok),
+    ctx.set('Content-Type', 'application/json'),
+    ctx.set('X-request-Id', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'),
+    ctx.set('X-lambda-request-Id', 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'),
+    ctx.json({
+      unknown: 'cat',
+    })
+  );


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-bff/issues/7

# 関連 URL

- `POST /cat-images/validation-results`

# Done の定義

- https://github.com/nekochans/lgtm-cat-bff/issues/7 のDoneの定義を満たしている事

# スクリーンショット

なし

# 変更点概要

ねこ画像検証APIへリクエストする処理を追加。

## サンプルリクエスト

```
echo '{"image" : "'"$( base64 ./adpDSC_6635-760x507-1.jpg)"'", "imageExtension": ".jpg"}' | \
curl -v -X POST -H "Content-Type: application/json" \
-d @- http://localhost:8787/cat-images/validation-results | jq
```

## サンプルレスポンス

```
{
  "isAcceptableCatImage": true
}
```

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし