### PR TITLE
POST /lgtm-images（画像アップロード）へ通信するエンドポイントを実装

### DIFF
--- a/src/api/__tests__/uploadLgtmImage.spec.ts
+++ b/src/api/__tests__/uploadLgtmImage.spec.ts
@@ -5,7 +5,12 @@ import 'whatwg-fetch';
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
 import { mockUploadLgtmImage } from '../../mocks/api/mockUploadLgtmImage';
+import { mockUploadLgtmImagePayloadTooLargeError } from '../../mocks/api/mockUploadLgtmImagePayloadTooLargeError';
+import { mockUploadLgtmImageUnexpectedResponseBody } from '../../mocks/api/mockUploadLgtmImageUnexpectedResponseBody';
+import { mockUploadLgtmImageUnprocessableEntityError } from '../../mocks/api/mockUploadLgtmImageUnprocessableEntityError';
 import { isSuccessResult } from '../../result';
+import { UploadLgtmImageError } from '../errors/UploadLgtmImageError';
+import { UploadLgtmImagePayloadTooLargeError } from '../errors/UploadLgtmImagePayloadTooLargeError';
 import { uploadLgtmImage } from '../uploadLgtmImage';
 
 const apiUrl = 'https://api.example.com';
@@ -45,5 +50,76 @@ describe('uploadLgtmImage TestCases', () => {
 
     expect(isSuccessResult(result)).toBeTruthy();
     expect(result.value).toStrictEqual(expected);
+  });
+
+  it('should return a UploadLgtmImagePayloadTooLargeError because the API returns 413', async () => {
+    mockServer.use(
+      rest.post(
+        `${apiUrl}/lgtm-images`,
+        mockUploadLgtmImagePayloadTooLargeError
+      )
+    );
+
+    const expected = {
+      error: new UploadLgtmImagePayloadTooLargeError(
+        'X-Request-Id=aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa:X-Lambda-Request-Id:bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'
+      ),
+      xRequestId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+      xLambdaRequestId: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+    };
+
+    const result = await uploadLgtmImage({
+      apiBaseUrl: apiUrl,
+      accessToken: '',
+      jsonRequestBody: JSON.stringify({ image: '', imageExtension: '.png' }),
+    });
+
+    expect(isSuccessResult(result)).toBeFalsy();
+    expect(result.value).toStrictEqual(expected);
+  });
+
+  it('should return a ValidationErrorResponse because the API returns an unexpected response body', async () => {
+    mockServer.use(
+      rest.post(
+        `${apiUrl}/lgtm-images`,
+        mockUploadLgtmImageUnexpectedResponseBody
+      )
+    );
+
+    const expected = {
+      invalidParams: [{ name: 'imageUrl', reason: 'Invalid url' }],
+      xRequestId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+      xLambdaRequestId: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+    };
+
+    const result = await uploadLgtmImage({
+      apiBaseUrl: apiUrl,
+      accessToken: '',
+      jsonRequestBody: JSON.stringify({ image: '', imageExtension: '.png' }),
+    });
+
+    expect(isSuccessResult(result)).toBeFalsy();
+    expect(result.value).toStrictEqual(expected);
+  });
+
+  it('should Throw UploadLgtmImageError because the API returns an unexpected error', async () => {
+    mockServer.use(
+      rest.post(
+        `${apiUrl}/lgtm-images`,
+        mockUploadLgtmImageUnprocessableEntityError
+      )
+    );
+
+    await expect(
+      uploadLgtmImage({
+        apiBaseUrl: apiUrl,
+        accessToken: '',
+        jsonRequestBody: JSON.stringify({ image: '', imageExtension: '.png' }),
+      })
+    ).rejects.toStrictEqual(
+      new UploadLgtmImageError(
+        'X-Request-Id=aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa:X-Lambda-Request-Id:bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'
+      )
+    );
   });
 });

--- a/src/api/__tests__/uploadLgtmImage.spec.ts
+++ b/src/api/__tests__/uploadLgtmImage.spec.ts
@@ -1,0 +1,49 @@
+/**
+ * @jest-environment jsdom
+ */
+import 'whatwg-fetch';
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+import { mockUploadLgtmImage } from '../../mocks/api/mockUploadLgtmImage';
+import { isSuccessResult } from '../../result';
+import { uploadLgtmImage } from '../uploadLgtmImage';
+
+const apiUrl = 'https://api.example.com';
+
+const mockHandlers = [rest.post(`${apiUrl}/lgtm-images`, mockUploadLgtmImage)];
+
+const mockServer = setupServer(...mockHandlers);
+
+// eslint-disable-next-line max-lines-per-function
+describe('uploadLgtmImage TestCases', () => {
+  beforeAll(() => {
+    mockServer.listen();
+  });
+
+  afterEach(() => {
+    mockServer.resetHandlers();
+  });
+
+  afterAll(() => {
+    mockServer.close();
+  });
+
+  // eslint-disable-next-line max-lines-per-function
+  it('should return createdLgtmImageUrl.', async () => {
+    const expected = {
+      createdLgtmImageUrl:
+        'https://stg-lgtm-images.lgtmeow.com/2023/01/10/21/58cad97b-9732-4d71-8c50-ea2ea1f1cb51.webp',
+      xRequestId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+      xLambdaRequestId: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+    };
+
+    const result = await uploadLgtmImage({
+      apiBaseUrl: apiUrl,
+      accessToken: '',
+      jsonRequestBody: JSON.stringify({ image: '', imageExtension: '.jpeg' }),
+    });
+
+    expect(isSuccessResult(result)).toBeTruthy();
+    expect(result.value).toStrictEqual(expected);
+  });
+});

--- a/src/api/errors/UploadLgtmImageError.ts
+++ b/src/api/errors/UploadLgtmImageError.ts
@@ -1,0 +1,6 @@
+export class UploadLgtmImageError extends Error {
+  constructor(error?: string) {
+    super(error);
+    this.name = new.target.name;
+  }
+}

--- a/src/api/errors/UploadLgtmImagePayloadTooLargeError.ts
+++ b/src/api/errors/UploadLgtmImagePayloadTooLargeError.ts
@@ -1,0 +1,6 @@
+export class UploadLgtmImagePayloadTooLargeError extends Error {
+  constructor(error?: string) {
+    super(error);
+    this.name = new.target.name;
+  }
+}

--- a/src/api/uploadLgtmImage.ts
+++ b/src/api/uploadLgtmImage.ts
@@ -63,6 +63,9 @@ export const uploadLgtmImage = async (
 
   const response = await fetch(`${dto.apiBaseUrl}/lgtm-images`, options);
 
+  console.log(response.status);
+  console.log(`${dto.apiBaseUrl}/lgtm-images`);
+
   if (response.status !== httpStatusCode.accepted) {
     const requestIds = mightExtractRequestIds(response);
 

--- a/src/api/uploadLgtmImage.ts
+++ b/src/api/uploadLgtmImage.ts
@@ -1,0 +1,107 @@
+import { z } from 'zod';
+import { httpStatusCode } from '../httpStatusCode';
+import { createFailureResult, createSuccessResult, Result } from '../result';
+import { validation } from '../validator';
+import { UploadLgtmImageError } from './errors/UploadLgtmImageError';
+import type { JwtAccessToken } from './issueAccessToken';
+import {
+  LambdaRequestId,
+  mightExtractRequestIds,
+  RequestId,
+} from './mightExtractRequestIds';
+import {
+  createValidationErrorResponse,
+  ValidationErrorResponse,
+} from './validationErrorResponse';
+
+type Dto = {
+  apiBaseUrl: string;
+  accessToken: JwtAccessToken;
+  jsonRequestBody: string;
+};
+
+export type UploadLgtmImageResponse = {
+  imageUrl: `https://${string}`;
+};
+
+const uploadLgtmImageResponseSchema = z.object({
+  imageUrl: z.string().url(),
+});
+
+const isUploadLgtmImageResponse = (
+  value: unknown
+): value is UploadLgtmImageResponse => {
+  return validation(uploadLgtmImageResponseSchema, value).isValidate;
+};
+
+export type SuccessResponse = {
+  createdLgtmImageUrl: `https://${string}`;
+  xRequestId?: RequestId;
+  xLambdaRequestId?: LambdaRequestId;
+};
+
+export type FailureResponse = {
+  error: Error;
+  xRequestId?: RequestId;
+  xLambdaRequestId?: LambdaRequestId;
+};
+
+export const uploadLgtmImage = async (
+  dto: Dto
+): Promise<
+  Result<SuccessResponse, FailureResponse | ValidationErrorResponse>
+> => {
+  const options = {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${dto.accessToken}`,
+      'Content-Type': 'application/json',
+    },
+    body: dto.jsonRequestBody,
+  };
+
+  const response = await fetch(`${dto.apiBaseUrl}/lgtm-images`, options);
+
+  if (response.status !== httpStatusCode.accepted) {
+    const requestIds = mightExtractRequestIds(response);
+
+    throw new UploadLgtmImageError(
+      `X-Request-Id=${String(
+        requestIds.xRequestId
+      )}:X-Lambda-Request-Id:${String(requestIds.xLambdaRequestId)}`
+    );
+  }
+
+  const responseBody = await response.json();
+
+  if (isUploadLgtmImageResponse(responseBody)) {
+    const successResponse: SuccessResponse = {
+      createdLgtmImageUrl: responseBody.imageUrl,
+    };
+
+    const requestIds = mightExtractRequestIds(response);
+
+    return createSuccessResult<SuccessResponse>({
+      ...successResponse,
+      ...requestIds,
+    });
+  }
+
+  const validationResult = validation(
+    uploadLgtmImageResponseSchema,
+    responseBody
+  );
+  if (!validationResult.isValidate && validationResult.invalidParams != null) {
+    return createFailureResult<ValidationErrorResponse>(
+      createValidationErrorResponse(validationResult.invalidParams, response)
+    );
+  }
+
+  const requestIds = mightExtractRequestIds(response);
+
+  throw new UploadLgtmImageError(
+    `X-Request-Id=${String(requestIds.xRequestId)}:X-Lambda-Request-Id:${String(
+      requestIds.xLambdaRequestId
+    )}`
+  );
+};

--- a/src/handlers/handleUploadLgtmImage.ts
+++ b/src/handlers/handleUploadLgtmImage.ts
@@ -1,0 +1,114 @@
+import { z } from 'zod';
+import type { CacheClient } from '../api/cacheClient';
+import { issueAccessToken } from '../api/issueAccessToken';
+import { uploadLgtmImage } from '../api/uploadLgtmImage';
+import { isValidationErrorResponse } from '../api/validationErrorResponse';
+import { httpStatusCode } from '../httpStatusCode';
+import type { AcceptedTypesImageExtension } from '../lgtmImage';
+import { acceptedTypesImageExtensions } from '../lgtmImage';
+import { isFailureResult } from '../result';
+import { validation, ValidationResult } from '../validator';
+import {
+  createErrorResponse,
+  createSuccessResponse,
+  createValidationErrorResponse,
+  ResponseHeader,
+} from './handlerResponse';
+
+type Dto = {
+  env: {
+    cognitoTokenEndpoint: string;
+    cognitoClientId: string;
+    cognitoClientSecret: string;
+    apiBaseUrl: string;
+    cacheClient: CacheClient;
+  };
+  requestBody: {
+    image: string;
+    imageExtension: AcceptedTypesImageExtension;
+  };
+};
+
+export const validateHandleUploadLgtmImageRequestBody = (
+  value: unknown
+): ValidationResult => {
+  const schema = z.object({
+    image: z.string().min(1),
+    imageExtension: z.enum(acceptedTypesImageExtensions),
+  });
+
+  return validation(schema, value);
+};
+
+export const handleUploadLgtmImage = async (dto: Dto): Promise<Response> => {
+  const issueTokenRequest = {
+    endpoint: dto.env.cognitoTokenEndpoint,
+    cognitoClientId: dto.env.cognitoClientId,
+    cognitoClientSecret: dto.env.cognitoClientSecret,
+    cacheClient: dto.env.cacheClient,
+  };
+
+  const issueAccessTokenResult = await issueAccessToken(issueTokenRequest);
+  if (isFailureResult(issueAccessTokenResult)) {
+    const problemDetails = {
+      title: 'failed to issue access token',
+      type: 'InternalServerError',
+      status: httpStatusCode.internalServerError,
+    } as const;
+
+    return createErrorResponse(
+      problemDetails,
+      httpStatusCode.internalServerError
+    );
+  }
+
+  const jsonRequestBody = JSON.stringify(dto.requestBody);
+
+  const uploadLgtmImageDto = {
+    apiBaseUrl: dto.env.apiBaseUrl,
+    accessToken: issueAccessTokenResult.value.jwtAccessToken,
+    jsonRequestBody,
+  };
+
+  const uploadLgtmImageResult = await uploadLgtmImage(uploadLgtmImageDto);
+
+  const headers: ResponseHeader = {
+    'Content-Type': 'application/json',
+  };
+
+  if (uploadLgtmImageResult.value.xRequestId != null) {
+    headers['X-Request-Id'] = uploadLgtmImageResult.value.xRequestId;
+  }
+
+  if (uploadLgtmImageResult.value.xLambdaRequestId != null) {
+    headers['X-Lambda-Request-Id'] =
+      uploadLgtmImageResult.value.xLambdaRequestId;
+  }
+
+  if (isFailureResult(uploadLgtmImageResult)) {
+    if (isValidationErrorResponse(uploadLgtmImageResult.value)) {
+      return createValidationErrorResponse(
+        uploadLgtmImageResult.value.invalidParams,
+        headers
+      );
+    }
+
+    const problemDetails = {
+      title: 'failed to upload lgtm image payload too large',
+      type: 'PayloadTooLarge',
+      status: httpStatusCode.payloadTooLarge,
+    } as const;
+
+    return createErrorResponse(
+      problemDetails,
+      httpStatusCode.payloadTooLarge,
+      headers
+    );
+  }
+
+  const responseBody = {
+    createdLgtmImageUrl: uploadLgtmImageResult.value.createdLgtmImageUrl,
+  };
+
+  return createSuccessResponse(responseBody, httpStatusCode.accepted, headers);
+};

--- a/src/handlers/handlerResponse.ts
+++ b/src/handlers/handlerResponse.ts
@@ -19,7 +19,7 @@ export const createSuccessResponse = (
 
 export type ProblemDetails = {
   title: string;
-  type: 'ResourceNotFound' | 'InternalServerError';
+  type: 'ResourceNotFound' | 'InternalServerError' | 'PayloadTooLarge';
   status?: HttpStatusCode;
   detail?: string;
 };

--- a/src/httpStatusCode.ts
+++ b/src/httpStatusCode.ts
@@ -9,6 +9,7 @@ export const httpStatusCode = {
   forbidden: 403,
   notFound: 404,
   requestTimeout: 408,
+  payloadTooLarge: 413,
   unprocessableEntity: 422,
   internalServerError: 500,
   serviceUnavailable: 503,

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,10 @@ import {
 import { handleFetchLgtmImagesInRandom } from './handlers/handleFetchLgtmImagesInRandom';
 import { handleFetchLgtmImagesInRecentlyCreated } from './handlers/handleFetchLgtmImagesInRecentlyCreated';
 import { handleNotFound } from './handlers/handleNotFound';
+import {
+  handleUploadLgtmImage,
+  validateHandleUploadLgtmImageRequestBody,
+} from './handlers/handleUploadLgtmImage';
 import type { ProblemDetails } from './handlers/handlerResponse';
 import { createValidationErrorResponse } from './handlers/handlerResponse';
 import { httpStatusCode } from './httpStatusCode';
@@ -41,6 +45,29 @@ app.get('/lgtm-images', async (c) => {
       cacheClient: c.env.COGNITO_TOKEN,
     },
   });
+});
+
+app.post('/lgtm-images', async (c) => {
+  const env = {
+    cognitoTokenEndpoint: c.env.COGNITO_TOKEN_ENDPOINT,
+    cognitoClientId: c.env.COGNITO_CLIENT_ID,
+    cognitoClientSecret: c.env.COGNITO_CLIENT_SECRET,
+    apiBaseUrl: c.env.LGTMEOW_API_URL,
+    cacheClient: c.env.COGNITO_TOKEN,
+  };
+
+  const requestBody = await c.req.json<{
+    image: string;
+    imageExtension: AcceptedTypesImageExtension;
+  }>();
+
+  const validationResult =
+    validateHandleUploadLgtmImageRequestBody(requestBody);
+  if (!validationResult.isValidate && validationResult.invalidParams != null) {
+    return createValidationErrorResponse(validationResult.invalidParams);
+  }
+
+  return await handleUploadLgtmImage({ env, requestBody });
 });
 
 app.get('/lgtm-images/recently-created', async (c) => {

--- a/src/mocks/api/mockUploadLgtmImage.ts
+++ b/src/mocks/api/mockUploadLgtmImage.ts
@@ -1,0 +1,18 @@
+import { ResponseResolver, MockedRequest, restContext } from 'msw';
+
+import { httpStatusCode } from '../../httpStatusCode';
+
+export const mockUploadLgtmImage: ResponseResolver<
+  MockedRequest,
+  typeof restContext
+> = (_req, res, ctx) =>
+  res(
+    ctx.status(httpStatusCode.accepted),
+    ctx.set('Content-Type', 'application/json'),
+    ctx.set('X-request-Id', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'),
+    ctx.set('X-lambda-request-Id', 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'),
+    ctx.json({
+      imageUrl:
+        'https://stg-lgtm-images.lgtmeow.com/2023/01/10/21/58cad97b-9732-4d71-8c50-ea2ea1f1cb51.webp',
+    })
+  );

--- a/src/mocks/api/mockUploadLgtmImagePayloadTooLargeError.ts
+++ b/src/mocks/api/mockUploadLgtmImagePayloadTooLargeError.ts
@@ -1,0 +1,17 @@
+import { ResponseResolver, MockedRequest, restContext } from 'msw';
+
+import { httpStatusCode } from '../../httpStatusCode';
+
+export const mockUploadLgtmImagePayloadTooLargeError: ResponseResolver<
+  MockedRequest,
+  typeof restContext
+> = (_req, res, ctx) =>
+  res(
+    ctx.status(httpStatusCode.payloadTooLarge),
+    ctx.set('Content-Type', 'application/json'),
+    ctx.set('X-request-Id', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'),
+    ctx.set('X-lambda-request-Id', 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'),
+    ctx.json({
+      message: 'Request Entity Too Large',
+    })
+  );

--- a/src/mocks/api/mockUploadLgtmImageUnexpectedResponseBody.ts
+++ b/src/mocks/api/mockUploadLgtmImageUnexpectedResponseBody.ts
@@ -1,0 +1,17 @@
+import { ResponseResolver, MockedRequest, restContext } from 'msw';
+
+import { httpStatusCode } from '../../httpStatusCode';
+
+export const mockUploadLgtmImageUnexpectedResponseBody: ResponseResolver<
+  MockedRequest,
+  typeof restContext
+> = (_req, res, ctx) =>
+  res(
+    ctx.status(httpStatusCode.accepted),
+    ctx.set('Content-Type', 'application/json'),
+    ctx.set('X-request-Id', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'),
+    ctx.set('X-lambda-request-Id', 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'),
+    ctx.json({
+      imageUrl: '',
+    })
+  );

--- a/src/mocks/api/mockUploadLgtmImageUnprocessableEntityError.ts
+++ b/src/mocks/api/mockUploadLgtmImageUnprocessableEntityError.ts
@@ -1,0 +1,17 @@
+import { ResponseResolver, MockedRequest, restContext } from 'msw';
+
+import { httpStatusCode } from '../../httpStatusCode';
+
+export const mockUploadLgtmImageUnprocessableEntityError: ResponseResolver<
+  MockedRequest,
+  typeof restContext
+> = (_req, res, ctx) =>
+  res(
+    ctx.status(httpStatusCode.unprocessableEntity),
+    ctx.set('Content-Type', 'application/json'),
+    ctx.set('X-request-Id', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'),
+    ctx.set('X-lambda-request-Id', 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'),
+    ctx.json({
+      message: 'Unprocessable Entity',
+    })
+  );


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-bff/issues/8

# 関連 URL

- `POST /lgtm-images`

# Done の定義

- 画像アップロード用のエンドポイントが実装されている事

# スクリーンショット

なし

# 変更点概要

画像アップロード用のAPIに通信する処理を実装。

## 正常レスポンス

```
{
  "createdLgtmImageUrl": "https://stg-lgtm-images.lgtmeow.com/2023/01/12/23/4d30338a-3a85-451e-979d-21df06a83836.webp"
}
```

## 巨大な画像をアップロードして413が返ってきた時のResponse
```
{
  "title": "failed to upload lgtm image payload too large",
  "type": "PayloadTooLarge",
  "status": 413
}
```

## バリデーションError

```
{
  "title": "unprocessable entity",
  "type": "ValidationError",
  "status": 422,
  "invalidParams": [
    {
      "name": "image",
      "reason": "String must contain at least 1 character(s)"
    },
    {
      "name": "imageExtension",
      "reason": "Invalid enum value. Expected '.png' | '.jpg' | '.jpeg', received '.webp'"
    }
  ]
}
```

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし